### PR TITLE
Drawing a trail path of an Autonomous mover

### DIFF
--- a/mover.js
+++ b/mover.js
@@ -10,10 +10,20 @@ class AutonMover {
 
         this.maxSpeed = 5;
         this.maxForce = 0.125;
+
+        this.posHistory = [];
+        this.showHistory = true;
     }
 
     applyForce(force) {
         this.acc.add(force);
+    }
+
+    updateHistory(){
+        this.posHistory.push(this.pos.copy());
+        if (this.posHistory.length > 500) { 
+            this.posHistory.shift();
+        }
     }
 
     display(dinstingDirection = false, mouthSize = PI / 10) {
@@ -75,10 +85,29 @@ class Seeker extends AutonMover{
     }
 
     update(target, arrive = false, chk_edges = false) {
+        this.updateHistory();
+
         this.seek(target, arrive);
         this.vel.add(this.acc);
         this.pos.add(this.vel);
         this.acc.mult(0);
+
         if (chk_edges) { this.checkEdges(); }
+    }
+
+    display(dinstingDirection = false, mouthSize = PI / 10) {
+        if (this.showHistory) {
+            for (let i = 0; i < this.posHistory.length-1; i++) {
+                let prevPos = this.posHistory[i];
+                let currPos = this.posHistory[i + 1];
+
+                let posChange = p5.Vector.dist(prevPos, currPos);
+                if (posChange >= windowWidth || posChange >= windowHeight) {
+                    continue;
+                }
+                line(prevPos.x, prevPos.y, currPos.x, currPos.y);
+            }
+        }
+        super.display(dinstingDirection, mouthSize);
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature to track and display the position history of `AutonMover` and its subclass `Seeker` in the `mover.js` file. The changes primarily focus on adding a position history mechanism and updating the display method to visualize this history.

### Implementation steps for drawing trial path:

- Added a `posHistory` array and a `showHistory` boolean to the `AutonMover` class to store and control the display of position history resepctively
- Implemented the `updateHistory` method in the `AutonMover` class to add position vectors to the `posHistory` list and to ensure it doesn't exceed **500 entries**.

### Updates to `Seeker` class:

To reflect the above changes `Seeker` was changed as mentioned below:
-  Modified the `update()` method  to call `updateHistory()` method from its parent `AutonMover`
-  Enhanced the `display()` method to draw lines between historical positions if `showHistory` is enabled, visualizing the movement path (**Note**: this functionality isn't added to `AutonMover` because visualising the history can be done differently for different _Autonomous movers_)